### PR TITLE
[MVI-689] TuneRequest - Provide default or many on request.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ brew-python:
 
 clean:
 	@echo "======================================================"
-	@echo clean $(PACKAGE)
+	@echo clean: $(PACKAGE)
 	@echo "======================================================"
 	rm -fR __pycache__ venv "*.pyc" build/*    \
 		$(PACKAGE_PREFIX)/__pycache__/         \
@@ -61,10 +61,16 @@ clean:
 		$(PACKAGE_PREFIX).egg-info/*
 	find ./* -maxdepth 0 -name "*.pyc" -type f -delete
 	find $(PACKAGE_PREFIX) -name "*.pyc" -type f -delete
+	@echo "======================================================"
+	@echo delete distributions: $(PACKAGE)
+	@echo "======================================================"
+	mkdir -p ./dist/
+	find ./dist/ -name $(PACKAGE_WILDCARD) -exec rm -vf {} \;
+	find ./dist/ -name $(PACKAGE_PREFIX_WILDCARD) -exec rm -vf {} \;
 
 uninstall-package: clean
 	@echo "======================================================"
-	@echo uninstall-package $(PACKAGE)
+	@echo uninstall-package: $(PACKAGE)
 	@echo "======================================================"
 	$(PIP3) install --upgrade list
 	@if $(PIP3) list --format=legacy | grep -F $(PACKAGE) > /dev/null; then \
@@ -77,14 +83,13 @@ uninstall-package: clean
 
 remove-package: uninstall-package
 	@echo "======================================================"
-	@echo remove-package $(PACKAGE_PREFIX)
+	@echo remove-package: $(PACKAGE_PREFIX)
 	@echo "======================================================"
 	rm -fR $(PYTHON3_SITE_PACKAGES)/$(PACKAGE_PREFIX)*
 
-# Install the module from a binary distribution archive.
 install: remove-package
 	@echo "======================================================"
-	@echo install $(PACKAGE)
+	@echo install: $(PACKAGE)
 	@echo "======================================================"
 	$(PIP3) install --upgrade pip
 	$(PIP3) install --upgrade $(WHEEL_ARCHIVE)
@@ -124,12 +129,6 @@ local-dev: remove-package
 
 dist: clean
 	@echo "======================================================"
-	@echo remove $(PACKAGE_PREFIX_WILDCARD) and $(PACKAGE_WILDCARD)
-	@echo "======================================================"
-	mkdir -p ./dist/
-	find ./dist/ -name $(PACKAGE_WILDCARD) -exec rm -vf {} \;
-	find ./dist/ -name $(PACKAGE_PREFIX_WILDCARD) -exec rm -vf {} \;
-	@echo "======================================================"
 	@echo dist $(PACKAGE)
 	@echo "======================================================"
 	$(PIP3) install --upgrade -r requirements.txt
@@ -139,12 +138,6 @@ dist: clean
 	ls -al ./dist/$(PACKAGE_PREFIX_WILDCARD)
 
 build: clean
-	@echo "======================================================"
-	@echo remove $(PACKAGE_PREFIX_WILDCARD) and $(PACKAGE_WILDCARD)
-	@echo "======================================================"
-	mkdir -p ./dist/
-	find ./dist/ -name $(PACKAGE_WILDCARD) -exec rm -vf {} \;
-	find ./dist/ -name $(PACKAGE_PREFIX_WILDCARD) -exec rm -vf {} \;
 	@echo "======================================================"
 	@echo build $(PACKAGE)
 	@echo "======================================================"
@@ -238,5 +231,5 @@ docs-doxygen:
 	sudo doxygen docs/Doxyfile
 	x-www-browser docs/doxygen/html/index.html
 
-example:
+run-examples:
 	$(PYTHON3) examples/example_request.py

--- a/requests_mv_integrations/exceptions/custom.py
+++ b/requests_mv_integrations/exceptions/custom.py
@@ -27,6 +27,7 @@ class TuneRequestClientGoneError(TuneRequestModuleError):
             TuneRequestErrorCodes.GONE
         super(TuneRequestClientGoneError, self).__init__(error_code=error_code, **kwargs)
 
+
 class TuneRequestValueError(TuneRequestModuleError):
     """Request Mv Integration: Value error"""
 


### PR DESCRIPTION
Either provide default `TuneRequest` at __init__ or define at time of `self.request()`.
This allows usage `self.request()` for all currently implemented mv-integrations to still define the `request_retry` properties.