### PR TITLE
[MVI-728] (tune-mv-integrations) Error Origin

### DIFF
--- a/requests_mv_integrations/__init__.py
+++ b/requests_mv_integrations/__init__.py
@@ -4,8 +4,8 @@
 #  @namespace requests_mv_integrations
 
 __title__ = 'requests-mv-integrations'
-__version__ = '0.1.5'
-__build__ = 0x000104
+__version__ = '0.1.6'
+__build__ = 0x000106
 __version_info__ = tuple(__version__.split('.'))
 
 __author__ = 'jefft@tune.com'

--- a/requests_mv_integrations/exceptions/base.py
+++ b/requests_mv_integrations/exceptions/base.py
@@ -4,6 +4,7 @@
 #  @namespace requests_mv_integrations
 
 import six
+from requests_mv_integrations import (__title__)
 from requests_mv_integrations.support import (safe_str)
 from requests_mv_integrations.errors import (TuneRequestErrorCodes, error_desc, error_name)
 
@@ -23,7 +24,7 @@ class TuneRequestBaseError(Exception):
     __error_status = None
     __error_reason = None
     __error_details = None
-    __error_origin = 'Module'
+    __error_origin = __title__
     __error_request_curl = None
 
     def __init__(


### PR DESCRIPTION
1. Modified `error_origin` to this package's `__title__`.