### PR TITLE
[MIV-769] (requests-mv-integrations) Adapter Error

### DIFF
--- a/requests_mv_integrations/__init__.py
+++ b/requests_mv_integrations/__init__.py
@@ -4,8 +4,8 @@
 #  @namespace requests_mv_integrations
 
 __title__ = 'requests-mv-integrations'
-__version__ = '0.1.6'
-__build__ = 0x000106
+__version__ = '0.1.7'
+__build__ = 0x000107
 __version_info__ = tuple(__version__.split('.'))
 
 __author__ = 'jefft@tune.com'

--- a/requests_mv_integrations/request_mv_integration.py
+++ b/requests_mv_integrations/request_mv_integration.py
@@ -12,10 +12,7 @@ import time
 import urllib.parse
 from functools import partial
 
-import bs4
 import requests
-import requests_toolbelt
-import xmltodict
 from logging_mv_integrations import (
     TuneLoggingFormat,
     TuneLoggingHandler,

--- a/requests_mv_integrations/support/tune_request.py
+++ b/requests_mv_integrations/support/tune_request.py
@@ -50,7 +50,13 @@ class TuneRequest(metaclass=Singleton):
         try:
             return self.session.request(method=request_method, url=request_url, **kwargs)
         except Exception as ex:
-            log.error(get_exception_message(ex))
+            log.warning(
+                "Session Request: Failed: {}".format(get_exception_message(ex)),
+                extra={
+                    'request_method': request_method,
+                    'request_url': request_url
+                }
+            )
             raise
 
     def request_safe(self, request_method, request_url, response_hook=None, exception_handler=None, **kwargs):
@@ -61,7 +67,13 @@ class TuneRequest(metaclass=Singleton):
                 method=request_method, url=request_url, hooks={'response': response_hook}, **kwargs
             )
         except Exception as ex:
-            log.error(get_exception_message(ex))
+            log.warning(
+                "Session Request: Failed: {}".format(get_exception_message(ex)),
+                extra={
+                    'request_method': request_method,
+                    'request_url': request_url
+                }
+            )
             exception_handler(ex)
             return None
 


### PR DESCRIPTION
Added log warning when any `Exception` is raised from `session.request`.
This is temporary until we understand all intermittent `Exception` and handle them correctly.