### PR TITLE
[MVI-741] (unit testing, requests_mv_integration/response/validate_test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ sonar-project.properties
 .sonar
 
 dist/*
+
+# pytest
+.cache/*
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  __init__.py
+#
+#  Copyright (c) 2016 TUNE, Inc.
+#  All rights reserved.
+#
+#  Python 3.0
+#
+#  @category  request_mv_integration
+#  @package   request_mv_integration
+#  @author    TLV Developers <tlvdev@tune.com>
+#  @copyright 2016 TUNE, Inc. (http://www.tune.com)
+#  @license   http://opensource.org/licenses/MIT The MIT License (MIT)
+#  @link      https://developers.tune.com @endlink

--- a/tests/support/response/validate_test.py
+++ b/tests/support/response/validate_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  @copyright 2016 TUNE, Inc. (http://www.tune.com)
+#  @namespace requests_mv_integration
+
+import pytest
+
+from requests_mv_integrations.support.response import validate_response
+from requests_mv_integrations.exceptions import TuneRequestModuleError
+from requests.models import Response, codes
+
+response_ok = Response()
+response_ok.status_code = codes.ok
+response_bad = Response()
+response_bad.status_code = codes.bad
+
+
+_test_validate = [
+    (response_ok, True),
+    (response_bad, False)
+]
+
+
+@pytest.mark.parametrize("response, expected", _test_validate)
+def test_validate_response(response, expected):
+    res = True
+    try:
+        validate_response(
+            response=response,
+            request_curl="Not important request curl",
+            request_label="Not important request label",
+        )
+    except TuneRequestModuleError:
+        res = False
+    assert res == expected


### PR DESCRIPTION
Tested only validate_response() function.
validate_json_response is uncovered.