### PR TITLE
[MVI-934] (requests-mv-integrations) curl: GET data

### DIFF
--- a/requests_mv_integrations/__init__.py
+++ b/requests_mv_integrations/__init__.py
@@ -4,8 +4,8 @@
 #  @namespace requests_mv_integrations
 
 __title__ = 'requests-mv-integrations'
-__version__ = '0.03.1'
-__build__ = 0x000301
+__version__ = '0.03.2'
+__build__ = 0x000302
 __version_info__ = tuple(__version__.split('.'))
 
 __author__ = 'jefft@tune.com'

--- a/requests_mv_integrations/support/curl.py
+++ b/requests_mv_integrations/support/curl.py
@@ -11,6 +11,7 @@ from base64 import b64encode
 import requests
 import shlex
 import argparse
+from requests_mv_integrations.support.utils import urlencode_dict
 
 # from pprintpp import pprint
 
@@ -108,7 +109,10 @@ def command_line_request_curl(
 
     if request_method == 'GET':
         if request_data:
-            params = request_data.split("&")
+            if isinstance(request_data, str):
+                params = request_data.split("&")
+            elif isinstance(request_data, dict):
+                params = urlencode_dict(request_data).split("&")
 
             command += (" -G" " --data {params}" " '{url}'")
 

--- a/tests/support/test_curl.py
+++ b/tests/support/test_curl.py
@@ -11,13 +11,33 @@ from requests.auth import HTTPBasicAuth
 from requests_mv_integrations.support.curl import command_line_request_curl, parse_curl
 from requests_mv_integrations.support.constants import __MODULE_VERSION__, __PYTHON_VERSION__
 
-_test_command_line_request_curl_get = [(
+_test_command_line_request_curl_get_data_str = [(
     'GET',
     'https://api.partner.com/find',
     {
         'Content-Type': 'application/json'
     },
     'api_key=11111111222222223333333344444444',
+    (
+        "curl --verbose -X GET "
+        "-H 'Content-Type: application/json' "
+        "-H 'User-Agent: (requests-mv-integrations/{module_version}, Python/{python_version})' "
+        "--connect-timeout 60 -L -G --data 'api_key=11111111222222223333333344444444' "
+        "'https://api.partner.com/find'"
+    ).format(
+        module_version=__MODULE_VERSION__, python_version=__PYTHON_VERSION__
+    ),
+),]
+
+_test_command_line_request_curl_get_data_dict = [(
+    'GET',
+    'https://api.partner.com/find',
+    {
+        'Content-Type': 'application/json'
+    },
+    {
+        'api_key': '11111111222222223333333344444444'
+    },
     (
         "curl --verbose -X GET "
         "-H 'Content-Type: application/json' "
@@ -50,7 +70,26 @@ _test_command_line_request_curl_get_auth = [(
 
 
 @pytest.mark.parametrize(
-    "request_method, request_url, request_headers, request_data, curl_expected", _test_command_line_request_curl_get
+    "request_method, request_url, request_headers, request_data, curl_expected",
+    _test_command_line_request_curl_get_data_str,
+)
+def test_curl_get_data(request_method, request_url, request_data, request_headers, curl_expected):
+    curl_actual = command_line_request_curl(
+        request_method=request_method,
+        request_url=request_url,
+        request_headers=request_headers,
+        request_data=request_data
+    )
+
+    parsed_curl_actual = parse_curl(curl_actual)
+    parsed_curl_expected = parse_curl(curl_expected)
+    ddiff = DeepDiff(parsed_curl_actual, parsed_curl_expected, ignore_order=True)
+
+    assert ddiff == {}
+
+@pytest.mark.parametrize(
+    "request_method, request_url, request_headers, request_data, curl_expected",
+    _test_command_line_request_curl_get_data_dict,
 )
 def test_curl_get_data(request_method, request_url, request_data, request_headers, curl_expected):
     curl_actual = command_line_request_curl(
@@ -68,7 +107,8 @@ def test_curl_get_data(request_method, request_url, request_data, request_header
 
 
 @pytest.mark.parametrize(
-    "request_method, request_url, request_headers, request_params, curl_expected", _test_command_line_request_curl_get
+    "request_method, request_url, request_headers, request_params, curl_expected",
+    _test_command_line_request_curl_get_data_str,
 )
 def test_curl_get_params(request_method, request_url, request_params, request_headers, curl_expected):
     curl_actual = command_line_request_curl(
@@ -87,7 +127,7 @@ def test_curl_get_params(request_method, request_url, request_params, request_he
 
 @pytest.mark.parametrize(
     "request_method, request_url, request_headers, request_auth, curl_expected",
-    _test_command_line_request_curl_get_auth
+    _test_command_line_request_curl_get_auth,
 )
 def test_curl_get_auth(request_method, request_url, request_auth, request_headers, curl_expected):
     curl_actual = command_line_request_curl(


### PR DESCRIPTION
Fix building `curl` for method `GET` and `request_data`.