### PR TITLE
[MVI-1109] (requests_mv_integrations) Fix bug to safe_float

### DIFF
--- a/requests_mv_integrations/support/safe_cast.py
+++ b/requests_mv_integrations/support/safe_cast.py
@@ -5,7 +5,8 @@
 
 
 def safe_cast(val, to_type, default=None):
-    """Safely cast value to type, and if failed, returned default.
+    """Safely cast value to type, and if failed, returned default if exists.
+        If default is 'None' and and error occurs, it is raised.
 
     Args:
         val:
@@ -20,53 +21,66 @@ def safe_cast(val, to_type, default=None):
 
     try:
         return to_type(val)
-    except ValueError:
-        return default
+    except ValueError as ex:
+        if default is not None:
+            return default
+        else:
+            raise ex
 
 
-def safe_str(val):
-    """Safely cast value to str
+def safe_str(val, default=None):
+    """Safely cast value to str, Optional: Pass default value. Returned if casting fails.
 
     Args:
         val:
+        default:
 
     Returns:
 
     """
-    return safe_cast(val, str, "")
+    if val is None:
+        return ''
+    return safe_cast(val, str, default)
 
 
-def safe_float(val, ndigits=2):
-    """Safely cast value to float
+def safe_float(val, ndigits=2, default=None):
+    """Safely cast value to float, remove ',' if exists to ensure strs like: "1,234.5" are handled
+        Optional: Pass default value. Returned if casting fails.
 
     Args:
         val:
+        ndigits:
+        default:
 
     Returns:
 
     """
-    return round(safe_cast(val, float, 0.0), ndigits)
+    tmp_val = val.replace(',', '') if type(val) == str else val
+    return round(safe_cast(tmp_val, float, default), ndigits)
 
 
-def safe_int(val):
-    """Safely cast value to int
+def safe_int(val, default=None):
+    """Safely cast value to int. Optional: Pass default value. Returned if casting fails.
 
     Args:
         val:
+        default:
 
     Returns:
 
     """
-    return safe_cast(safe_float(val, 0), int, 0)
+    return safe_cast(safe_float(val, ndigits=0, default=default), int, default)
 
 
-def safe_dict(val):
-    """Safely cast value to dict
+def safe_dict(val, default=None):
+    """Safely cast value to dict. Optional: Pass default value. Returned if casting fails.
 
     Args:
         val:
+        default:
 
     Returns:
 
     """
-    return safe_cast(val, dict, {})
+    return safe_cast(val, dict, default)
+

--- a/tests/support/test_safe_cast.py
+++ b/tests/support/test_safe_cast.py
@@ -3,6 +3,8 @@
 #  @copyright 2017 TUNE, Inc. (http://www.tune.com)
 #  @namespace requests_mv_integration
 
+import pytest
+
 from requests_mv_integrations.support.safe_cast import (
     safe_float,
     safe_str,
@@ -12,21 +14,75 @@ from requests_mv_integrations.support.safe_cast import (
 
 
 def test_safe_str():
+    # test type:
     assert isinstance(safe_str(0), str)
     assert isinstance(safe_str(0.0), str)
     assert isinstance(safe_str('0'), str)
+    # test str cast:
+    assert safe_str('') == ''
+    assert safe_str('Hello Jeff') == 'Hello Jeff'
+    assert safe_str('@%#$%^&*') == '@%#$%^&*'
+    assert safe_str(None) == ''
+    # test numeric cast:
+    assert safe_str(0) == '0'
+    assert safe_str(10) == '10'
+    assert safe_str(-1) == '-1'
+    assert safe_str(10.52) == '10.52'
+    assert safe_str(-1.32) == '-1.32'
 
 
 def test_safe_int():
+    # test type:
     assert isinstance(safe_int(0), int)
     assert isinstance(safe_int(0.0), int)
     assert isinstance(safe_int('0'), int)
+    # test numeric cast:
+    assert safe_int(0) == 0
+    assert safe_int(10) == 10
+    assert safe_int(-1) == -1
+    assert safe_int(10.5) == 10
+    # test str cast:
+    assert safe_int('10') == 10
+    assert safe_int('-1') == -1
+    assert safe_int('1,000.5') == 1000
+    # test default param:
+    assert safe_int('###', 256) == 256
+    # test exception raising:
+    with pytest.raises(ValueError, message='Expecting ValueError to be raised'):
+        safe_int('##')
 
 
 def test_safe_float():
+    # test type:
     assert isinstance(safe_float(0), float)
     assert isinstance(safe_float(0.0), float)
+    assert isinstance(safe_float('0.0'), float)
+    assert isinstance(safe_float('1,252.5'), float)
+    # test numeric cast:
+    assert safe_float(0) == 0
+    assert safe_float(10.52) == 10.52
+    assert safe_float(-1) == -1
+    assert safe_float(-1.32) == -1.32
+    assert safe_float(10.5) == 10.5
+    # test str cast:
+    assert safe_float('1') == 1
+    assert safe_float('-1.32') == -1.32
+    assert safe_float('1,152.15') == 1152.15
+    # test num values after period:
+    assert safe_float(-1.321321, ndigits=6) == -1.321321
+    assert safe_float('-1.321321', ndigits=6) == -1.321321
+    # test default param:
+    assert safe_float('###', default=1.1) == 1.1
+    # test exception raising:
+    with pytest.raises(ValueError, message='Expecting ValueError to be raised'):
+        safe_float('##')
 
 
 def test_safe_dict():
+    # test basic dict:
     assert isinstance(safe_dict({'key': 'value'}), dict)
+    # test fail:
+    with pytest.raises(TypeError, message='Expecting TypeError because passing not iterable value.'):
+        assert safe_dict(5)
+    with pytest.raises(ValueError, message='Expecting ValueError because str not castable to dict.'):
+        assert safe_dict('Hello Jeff')


### PR DESCRIPTION
[MVI-1109] (requets_mv_integrations) Fix safe_cast and safe_float …

1. Update safe_float to handle commas inside a string number. This the
	value '1,235.5' will be cast correctly: 1235.5
2. Change safe_cast to fail in case there is a csating exception and no
	default value is supplied.
3. Set safe_str to retuen '' when the input is None since that is the
	expected behavior in our code and I decided to keep it the same.
4. Add testing to validate the new safe_cast capabilities.